### PR TITLE
Optimize recommendations

### DIFF
--- a/StreamBeat/Source/Algorithms/Comparators.h
+++ b/StreamBeat/Source/Algorithms/Comparators.h
@@ -40,4 +40,13 @@ namespace sb
             return a->getDurationSeconds() > b->getDurationSeconds();
         }
     };
+
+    class CompareByScoreDesc
+    {
+    public:
+        bool operator()(const std::pair<std::string, int>& a, const std::pair<std::string, int>& b) const
+        {
+            return a.second > b.second;
+        }
+    };
 }

--- a/StreamBeat/Source/Manager/DataManager.cpp
+++ b/StreamBeat/Source/Manager/DataManager.cpp
@@ -176,21 +176,13 @@ namespace sb
         std::string query = genre;
         std::transform(query.begin(), query.end(), query.begin(), ::tolower);
 
-        for (uint i = 0; i < songs_.size(); ++i)
-        {
-            const auto& song = songs_[i];
-            const auto& genres = song->getGenres();
-            for (uint j = 0; j < genres.size(); ++j)
-            {
-                std::string lowered = genres[j];
-                std::transform(lowered.begin(), lowered.end(), lowered.begin(), ::tolower);
-                if (lowered == query)
-                {
-                    result.push_back(song);
-                    break;
-                }
-            }
-        }
+        auto listPtr = songsByGenre_.find(query);
+        if (!listPtr)
+            return result;
+
+        for (uint i = 0; i < listPtr->size(); ++i)
+            result.push_back((*listPtr)[i]);
+
         return result;
     }
 
@@ -341,6 +333,17 @@ namespace sb
             songByName_.insert(currentSong->getName(), currentSong);
             songToAlbum_.insert(currentSong->getName(), currentAlbum->getName());
             songPartialIndex_.insert(currentSong);
+
+            const auto& genres = currentSong->getGenres();
+            for (uint i = 0; i < genres.size(); ++i)
+            {
+                std::string lowered = genres[i];
+                std::transform(lowered.begin(), lowered.end(), lowered.begin(), ::tolower);
+                if (!songsByGenre_.find(lowered))
+                    songsByGenre_.insert(lowered, List<std::shared_ptr<Song>>());
+
+                songsByGenre_[lowered].push_back(currentSong);
+            }
 
             currentSong = nullptr;
             currentCredits = nullptr;

--- a/StreamBeat/Source/Manager/DataManager.h
+++ b/StreamBeat/Source/Manager/DataManager.h
@@ -122,7 +122,8 @@ namespace sb
 		HashTable<std::string, std::shared_ptr<Album>> albumByName_;
 		HashTable<std::string, std::shared_ptr<Song>> songByName_;
 
-		HashTable<std::string, std::string> songToAlbum_;
-		HashTable<std::string, std::string> albumToArtist_;
-	};
+                HashTable<std::string, std::string> songToAlbum_;
+                HashTable<std::string, std::string> albumToArtist_;
+                HashTable<std::string, List<std::shared_ptr<Song>>> songsByGenre_;
+        };
 }

--- a/StreamBeat/Source/Manager/RecommendationManager.cpp
+++ b/StreamBeat/Source/Manager/RecommendationManager.cpp
@@ -1,4 +1,6 @@
 #include "RecommendationManager.h"
+#include "QuickSort.h"
+#include "Comparators.h"
 
 namespace sb
 {
@@ -109,17 +111,7 @@ namespace sb
         }
 
         List<std::pair<std::string, int>> sorted = score.toList();
-
-        for (uint i = 0; i < sorted.size(); ++i)
-        {
-            for (uint j = i + 1; j < sorted.size(); ++j)
-            {
-                if (sorted[j].second > sorted[i].second)
-                {
-                    std::swap(sorted[i], sorted[j]);
-                }
-            }
-        }
+        QuickSort<std::pair<std::string, int>, sb::CompareByScoreDesc>::sort(sorted);
 
         size_t added = 0;
         for (uint i = 0; i < sorted.size(); ++i)


### PR DESCRIPTION
## Summary
- index songs by genre in `DataManager`
- reuse genre index when searching songs by genre
- add comparator for sorting scores
- use QuickSort for recommendation ranking

## Testing
- `msbuild StreamBeat.sln /t:Build /p:Configuration=Release` *(fails: msbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cb8cea810832d8b73c36d490401d7